### PR TITLE
Fix instruction

### DIFF
--- a/doc_source/generic-linux-install.md
+++ b/doc_source/generic-linux-install.md
@@ -29,7 +29,8 @@ After the repository is added, you can install Corretto 8 by running this comman
 
 ### Download and Install the Debian Package Manually<a name="debian-deb-install-instruct"></a>
 
-1.  Download the Linux `.deb` file from the [Downloads](downloads-list.md) page\. Before you install the JDK, install the `java-common` package\.   
+1.  Download the Linux `.deb` file from the [Downloads](downloads-list.md) page\. Before you install the JDK, install the `java-common` package\. 
+
 **Example**  
 
    ```
@@ -37,6 +38,7 @@ After the repository is added, you can install Corretto 8 by running this comman
    ```
 
 1.  Install the `.deb` file by using `dpkg --install`\. e\.g\. install x86\_64 deb using the following command:  
+
 **Example**  
 
    ```

--- a/doc_source/generic-linux-install.md
+++ b/doc_source/generic-linux-install.md
@@ -19,6 +19,12 @@ To use the Corretto Apt repositories on Debian\-based systems, such as Ubuntu, i
  sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
 ```
 
+If the `add-apt-repository` doesn't work, try:
+
+```
+sudo add-apt-repository 'deb [arch=amd64] https://apt.corretto.aws stable main'
+```
+
 After the repository is added, you can install Corretto 8 by running this command:
 
 **Example**  


### PR DESCRIPTION
The `add-apt-repository` instruction doesn't work for my distribution (Linux Mint 19.3).

I have updated the instruction to add `[arch=amd64]` such that it works for me.